### PR TITLE
Ensure the window is shown on OS X

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -19,6 +19,7 @@ function createWindow () {
 
 	win.once('ready-to-show', () => {
 		win.maximize();
+		win.show();
 	});
 
 	win.on('closed', () => {


### PR DESCRIPTION
win.maximize() does not show the window on OS X,
so force it with win.show()